### PR TITLE
Fix bug when computing β in ITU618

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ write_test_cases.py
 .idea/misc.xml
 .idea/vcs.xml
 *.yaml
+.vscode/*

--- a/itur/__version__.py
+++ b/itur/__version__.py
@@ -2,4 +2,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/itur/models/itu618.py
+++ b/itur/models/itu618.py
@@ -16,7 +16,7 @@ from itur.models.itu838 import rain_specific_attenuation
 from itur.models.itu839 import rain_height
 from itur.models.itu1511 import topographic_altitude
 from itur.utils import prepare_input_array, prepare_output_array,\
-    prepare_quantity, compute_distance_earth_to_earth, get_input_type
+    prepare_quantity, compute_distance_earth_to_earth, get_input_type, EPSILON
 
 import warnings
 
@@ -192,7 +192,7 @@ class _ITU618_13():
         # Obtain the raingall rate, exceeded for 0.01% of an average year,
         # if not provided, as described in ITU-R P.837.
         if R001 is None:
-            R001 = rainfall_rate(lat, lon, 0.01).to(u.mm / u.hr).value
+            R001 = rainfall_rate(lat, lon, 0.01).to(u.mm / u.hr).value + EPSILON
 
         # Step 5: Obtain the specific attenuation gammar using the frequency
         # dependent coefficients as given in ITU-R P.838
@@ -210,8 +210,9 @@ class _ITU618_13():
         # for 0.01% of the time:
         eta = np.rad2deg(np.arctan2(hr - hs, Lg * r001))
 
+        Delta_h = np.where(hr - hs <= 0, EPSILON, (hr - hs))
         Lr = np.where(eta > el, Lg * r001 / np.cos(np.deg2rad(el)),
-                      (hr - hs) / np.sin(np.deg2rad(el)))
+                      Delta_h / np.sin(np.deg2rad(el)))
 
         xi = np.where(np.abs(lat) < 36, 36 - np.abs(lat), 0)
 
@@ -231,7 +232,7 @@ class _ITU618_13():
         if p >= 1:
             beta = np.zeros_like(A001)
         else:
-            beta = np.where(np.abs(lat) > 36,
+            beta = np.where(np.abs(lat) >= 36,
                             np.zeros_like(A001),
                             np.where((np.abs(lat) < 36) & (el > 25),
                                      -0.005 * (np.abs(lat) - 36),
@@ -532,7 +533,7 @@ class _ITU618_12():
         # Obtain the raingall rate, exceeded for 0.01% of an average year,
         # if not provided, as described in ITU-R P.837.
         if R001 is None:
-            R001 = rainfall_rate(lat, lon, 0.01).to(u.mm / u.hr).value
+            R001 = rainfall_rate(lat, lon, 0.01).to(u.mm / u.hr).value + EPSILON
 
         # Step 5: Obtain the specific attenuation gammar using the frequency
         # dependent coefficients as given in ITU-R P.838
@@ -548,9 +549,10 @@ class _ITU618_12():
         # Step 7: Calculate the vertical adjustment factor, v0.01,
         # for 0.01% of the time:
         eta = np.rad2deg(np.arctan2(hr - hs, Lg * r001))
-
+        
+        Delta_h = np.where(hr - hs <= 0, EPSILON, (hr - hs))
         Lr = np.where(eta > el, Lg * r001 / np.cos(np.deg2rad(el)),
-                      (hr - hs) / np.sin(np.deg2rad(el)))
+                      Delta_h / np.sin(np.deg2rad(el)))
 
         xi = np.where(np.abs(lat) < 36, 36 - np.abs(lat), 0)
 
@@ -570,7 +572,7 @@ class _ITU618_12():
         if p >= 1:
             beta = np.zeros_like(A001)
         else:
-            beta = np.where(np.abs(lat) > 36,
+            beta = np.where(np.abs(lat) >= 36,
                             np.zeros_like(A001),
                             np.where((np.abs(lat) < 36) & (el > 25),
                                      -0.005 * (np.abs(lat) - 36),

--- a/itur/utils.py
+++ b/itur/utils.py
@@ -32,6 +32,9 @@ __NUMERIC_TYPES__ = [numbers.Number, int, float, complex,
 # Define the geodetic system using the WSG-84 ellipsoid
 __wgs84_geod__ = Geod(ellps='WGS84')
 
+# A very small quantity used to avoid log(0) errors.
+EPSILON = 1e-9
+
 
 def load_data_interpolator(path_lat, path_lon, path_data, interp_fcn,
                            flip_ud=True):
@@ -230,7 +233,9 @@ def prepare_quantity(value, units=None, name_val=None):
 
     # If the units of the value are a temperature
     if isinstance(value, u.Quantity):
-        if units in [u.K, u.deg_C, u.Kelvin, u.Celsius, u.imperial.deg_F]:
+        if value.unit == units:
+            return value.value
+        elif units in [u.K, u.deg_C, u.Kelvin, u.Celsius, u.imperial.deg_F]:
             return value.to(units, equivalencies=u.temperature()).value
         else:
             return value.to(units).value


### PR DESCRIPTION
- The value of  β is 0 for lat <= 36 deg (missing equal sign).
- Added EPSILON, a small constant to prevent warning and errors when a) the model says that h_r < h_s, and b) the value of R001 = 0.
- Update version number to 0.3.3 for release