### PR TITLE
Ensure attenuation values (gas, cloud, rain, scintillation) are always positive

### DIFF
--- a/itur/__init__.py
+++ b/itur/__init__.py
@@ -17,42 +17,61 @@ frequency, geographic location and elevation angle. ITU-Rpy allows for fast,
 vectorial computation of the different contributions to the atmospheric
 attenuation.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
-__all__ = ['utils', 'plotting']
-import itur.utils
+__all__ = ["utils", "plotting"]
+import warnings
+
+import astropy.units as u
+import numpy as np
+
 import itur.plotting
+import itur.utils
 
+from .__version__ import __version__
 from .models.itu618 import rain_attenuation, scintillation_attenuation
-from .models.itu676 import gaseous_attenuation_slant_path, \
-    gaseous_attenuation_inclined_path, \
-    gaseous_attenuation_terrestrial_path
+from .models.itu676 import (
+    gaseous_attenuation_inclined_path,
+    gaseous_attenuation_slant_path,
+    gaseous_attenuation_terrestrial_path,
+)
 from .models.itu835 import standard_pressure
-from .models.itu836 import surface_water_vapour_density, \
-    total_water_vapour_content
+from .models.itu836 import surface_water_vapour_density, total_water_vapour_content
 from .models.itu840 import cloud_attenuation
 from .models.itu1510 import surface_mean_temperature
 from .models.itu1511 import topographic_altitude
 
-import numpy as np
-import warnings
-import astropy.units as u
-
-from .__version__ import __version__
-
 # Ignore divide by zero errors
-np.seterr(divide='ignore')
+np.seterr(divide="ignore")
 
 AUTHORS = "Inigo del Portillo"
 
 
 def atmospheric_attenuation_slant_path(
-        lat, lon, f, el, p, D, hs=None, rho=None, R001=None, eta=0.5, T=None,
-        H=None, P=None, hL=1e3, Ls=None, tau=45, V_t=None, mode='approx',
-        return_contributions=False, include_rain=True, include_gas=True,
-        include_scintillation=True, include_clouds=True):
+    lat,
+    lon,
+    f,
+    el,
+    p,
+    D,
+    hs=None,
+    rho=None,
+    R001=None,
+    eta=0.5,
+    T=None,
+    H=None,
+    P=None,
+    hL=1e3,
+    Ls=None,
+    tau=45,
+    V_t=None,
+    mode="approx",
+    return_contributions=False,
+    include_rain=True,
+    include_gas=True,
+    include_scintillation=True,
+    include_clouds=True,
+):
     """
     Calculate long-term atmospheric attenuation statistics for slant paths.
 
@@ -168,10 +187,12 @@ def atmospheric_attenuation_slant_path(
     if np.logical_or(p < 0.001, p > 50).any():
         warnings.warn(
             RuntimeWarning(
-                'The method to compute the total '
-                'atmospheric attenuation in recommendation ITU-P 618-13 '
-                'is only recommended for unavailabilities (p) between '
-                '0.001 % and 50 %'))
+                "The method to compute the total "
+                "atmospheric attenuation in recommendation ITU-P 618-13 "
+                "is only recommended for unavailabilities (p) between "
+                "0.001% and 50 %"
+            )
+        )
 
     # This takes account of the fact that a large part of the cloud attenuation
     # and gaseous attenuation is already included in the rain attenuation
@@ -216,8 +237,7 @@ def atmospheric_attenuation_slant_path(
         Ac = 0 * u.dB
 
     if include_scintillation:
-        As = scintillation_attenuation(lat, lon, f, el, p, D, eta,
-                                       T, H, P, hL)
+        As = scintillation_attenuation(lat, lon, f, el, p, D, eta, T, H, P, hL)
     else:
         As = 0 * u.dB
 

--- a/itur/__version__.py
+++ b/itur/__version__.py
@@ -2,4 +2,4 @@
 """Version information."""
 
 # The following line *must* be the last in the module, exactly as formatted:
-__version__ = "0.3.3"
+__version__ = "0.3.4"

--- a/itur/models/itu618.py
+++ b/itur/models/itu618.py
@@ -440,7 +440,7 @@ class _ITU618_13():
         return XPD_p
 
     @classmethod
-    def scintillation_attenuation_sigma(self, lat, lon, f, el, p, D, eta=0.5,
+    def scintillation_attenuation_sigma(cls, lat, lon, f, el, p, D, eta=0.5,
                                         T=None, H=None, P=None, hL=1000):
         # Step 1: For the value of t, calculate the saturation water vapour
         # pressure, es, (hPa), as specified in Recommendation ITU-R P.453.
@@ -478,11 +478,11 @@ class _ITU618_13():
         return sigma
 
     @classmethod
-    def scintillation_attenuation(self, lat, lon, f, el, p, D, eta=0.5, T=None,
+    def scintillation_attenuation(cls, lat, lon, f, el, p, D, eta=0.5, T=None,
                                   H=None, P=None, hL=1000):
         # Step 1 - 7: Calculate the standard deviation of the signal for the
         # applicable period and propagation path:
-        sigma = self.scintillation_attenuation_sigma(lat, lon, f, el, p,
+        sigma = cls.scintillation_attenuation_sigma(lat, lon, f, el, p,
                                                      D, eta, T, H, P, hL)
         # Step 8: Calculate the time percentage factor, a(p), for the time
         # percentage, p, in the range between 0.01% < p < 50%:
@@ -508,7 +508,7 @@ class _ITU618_12():
             warnings.warn(
                 RuntimeWarning('The method to compute the rain attenuation in '
                                'recommendation ITU-P 618-12 is only valid for '
-                               'unavailability values between 0.001 and 5'))
+                               'unavailability values between 0.001% and 5%'))
 
         Re = 8500   # Efective radius of the Earth (8500 km)
 
@@ -718,6 +718,11 @@ def rain_attenuation(lat, lon, f, el, hs=None, p=0.01, R001=None,
 
     val = __model.rain_attenuation(lat, lon, f, el, hs=hs, p=p,
                                    R001=R001, tau=tau, Ls=Ls)
+    
+    # The values of attenuation cannot be negative. The ITU models end up
+    # giving out negative values for certain inputs
+    val[val < 0] = 0
+    
     return prepare_output_array(val, type_output) * u.dB
 
 
@@ -931,6 +936,10 @@ def scintillation_attenuation(lat, lon, f, el, p, D, eta=0.5, T=None,
 
     val = __model.scintillation_attenuation(
         lat, lon, f, el, p, D, eta=eta, T=T, H=H, P=P, hL=hL)
+    
+    # The values of attenuation cannot be negative. The ITU models end up
+    # giving out negative values for certain inputs
+    val[val < 0] = 0
 
     return prepare_output_array(val, type_output) * u.dB
 

--- a/itur/models/itu676.py
+++ b/itur/models/itu676.py
@@ -17,10 +17,8 @@ from itur.models.itu836 import total_water_vapour_content
 from itur.models.itu1511 import topographic_altitude
 from itur.utils import (prepare_quantity, prepare_output_array, get_input_type,
                         prepare_input_array, load_data, dataset_dir)
-from functools import lru_cache
 
 
-@lru_cache(maxsize=1000)
 def __gamma0_exact__(self, f, p, rho, T):
     # T in Kelvin
     # e : water vapour partial pressure in hPa (total barometric pressure
@@ -58,7 +56,6 @@ def __gamma0_exact__(self, f, p, rho, T):
     return gamma
 
 
-@lru_cache(maxsize=1000)
 def __gammaw_exact__(self, f, p, rho, T):
     # T in Kelvin
     # e : water vapour partial pressure in hPa (total barometric pressure

--- a/itur/models/itu676.py
+++ b/itur/models/itu676.py
@@ -17,8 +17,10 @@ from itur.models.itu836 import total_water_vapour_content
 from itur.models.itu1511 import topographic_altitude
 from itur.utils import (prepare_quantity, prepare_output_array, get_input_type,
                         prepare_input_array, load_data, dataset_dir)
+from functools import lru_cache
 
 
+@lru_cache(maxsize=1000)
 def __gamma0_exact__(self, f, p, rho, T):
     # T in Kelvin
     # e : water vapour partial pressure in hPa (total barometric pressure
@@ -56,6 +58,7 @@ def __gamma0_exact__(self, f, p, rho, T):
     return gamma
 
 
+@lru_cache(maxsize=1000)
 def __gammaw_exact__(self, f, p, rho, T):
     # T in Kelvin
     # e : water vapour partial pressure in hPa (total barometric pressure
@@ -1370,6 +1373,11 @@ def gaseous_attenuation_slant_path(f, el, rho, P, T, V_t=None, h=None,
     h = prepare_quantity(h, u.km, 'Altitude')
     val = __model.gaseous_attenuation_slant_path(
         f, el, rho, P, T, V_t, h, mode)
+    
+    # The values of attenuation cannot be negative. The ITU models end up
+    # giving out negative values for certain inputs
+    val[val < 0] = 0
+
     return prepare_output_array(val, type_output) * u.dB
 
 

--- a/itur/models/itu840.py
+++ b/itur/models/itu840.py
@@ -686,6 +686,11 @@ def cloud_attenuation(lat, lon, el, f, p, Lred=None):
         Lred, u.kg / u.m**2,
         'Total columnar contents of reduced cloud liquid water.')
     val = __model.cloud_attenuation(lat, lon, el, f, p, Lred)
+    
+    # The values of attenuation cannot be negative. The ITU models end up
+    # giving out negative values for certain inputs
+    val[val < 0] = 0
+
     return prepare_output_array(val, type_output) * u.dB
 
 

--- a/test/itur_test.py
+++ b/test/itur_test.py
@@ -290,7 +290,7 @@ class TestIturUtils(test.TestCase):
     def test_distance_haversine(self):
         val = itur.utils.compute_distance_earth_to_earth_haversine(
             lat_p=0, lon_p=0, lat_grid=10, lon_grid=10)
-        self.assertEqual(val, 1568.5205567985759)
+        np.testing.assert_allclose(val, 1568.5205567985759)
 
         val = itur.utils.compute_distance_earth_to_earth_haversine(
             lat_p=0, lon_p=0, lat_grid=np.array([10, 20]),


### PR DESCRIPTION
Add check to ensure that all values returned by the functions below are always positive (i.e., we cannot have a negative attenuation which will actually correspond to a gain):
  - scintillation_attenuation
  - rain_attenuation
  - gaseous_slant_path_attenuation
  - cloud_attenuation