### PR TITLE
Fix array targets in P.1623 fade_depth and Ns/Ts coercion in P.1853

### DIFF
--- a/itur/models/itu1623.py
+++ b/itur/models/itu1623.py
@@ -219,18 +219,30 @@ class _ITU1623_1_:
 
     @classmethod
     def fade_depth(self, N_target, D_target, A, PofA, el, f):
+        # Each (N_target, D_target) pair is an independent root-finding
+        # problem: fsolve is given a scalar initial guess, so the residual has
+        # to stay scalar too. Broadcast the targets and solve them one by one.
+        n_target, d_target = np.broadcast_arrays(np.atleast_1d(N_target),
+                                                 np.atleast_1d(D_target))
 
-        d_target = np.atleast_1d(D_target)
+        def solve(n_t, d_t):
+            def delta_N_events(x):
+                P_it = 10 ** (np.interp(x, A, np.log10(PofA)))
+                T_tot_it = (P_it / 100) * 365.25 * 86400
+                _, _, N_it, _ = self.fade_duration(
+                    np.atleast_1d(d_t), x, el, f, T_tot_it)
+                delta = n_t - N_it
+                return delta
 
-        def delta_N_events(x):
-            P_it = 10 ** (np.interp(x, A, np.log10(PofA)))
-            T_tot_it = (P_it / 100) * 365.25 * 86400
-            _, _, N_it, _ = self.fade_duration(d_target, x, el, f, T_tot_it)
-            delta = N_target - N_it
-            return delta
+            a_min = fsolve(delta_N_events, 1)  # a_min has shape (1,)
+            return a_min.item()
 
-        a_min = fsolve(delta_N_events, 1)  # a_min should have shape (1,)
-        return a_min.item()
+        a_min = np.array([solve(n_t, d_t) for n_t, d_t
+                          in zip(n_target.ravel(), d_target.ravel())])
+
+        if np.ndim(N_target) == 0 and np.ndim(D_target) == 0:
+            return a_min.item()
+        return a_min.reshape(n_target.shape)
 
 
 class _ITU1623_0_:
@@ -622,10 +634,11 @@ def fade_depth(N_target, D_target, A, PofA, el, f):
 
     Parameters
     ----------
-    N_target : int
-        Target outage intensity (scalar)
-    D_target : int
-        Event duration (scalar)
+    N_target : number, sequence, or numpy.ndarray
+        Target outage intensity (number of events)
+    D_target : number, sequence, or numpy.ndarray
+        Event duration (seconds). Broadcast against `N_target`; each resulting
+        pair is solved independently
     A : number, sequence, or numpy.ndarray
         Attenuation distribution (CDF, A) for the link under analysis
     PofA : number, sequence, or numpy.ndarray
@@ -637,8 +650,10 @@ def fade_depth(N_target, D_target, A, PofA, el, f):
 
     Returns
     -------
-    a_min: number
-        Minimum attenuation the link must tolerate to meet the OI target
+    a_min: number or numpy.ndarray
+        Minimum attenuation the link must tolerate to meet the OI target.
+        A scalar if both `N_target` and `D_target` are scalars, otherwise an
+        array with their broadcast shape
 
     Remark
     ------

--- a/itur/models/itu1853.py
+++ b/itur/models/itu1853.py
@@ -24,6 +24,28 @@ from itur.utils import prepare_quantity
 from astropy import units as u
 
 
+def _prepare_sample_count(value, name_val, units=None):
+    """Coerce a sample count or sampling interval to a Python ``int``.
+
+    ``Ns`` and ``Ts`` end up as array sizes and slice steps, so they have to be
+    integral. Every other argument in this module accepts plain numbers and
+    astropy Quantities alike, and a Quantity always stores its value as a
+    float, so ``Ts=1 * u.s`` would otherwise reach numpy as ``1.0`` and fail
+    with an opaque ``TypeError: slice indices must be integers``.
+    """
+    if units is not None:
+        value = prepare_quantity(value, units, name_val)
+    value = getattr(value, 'value', value)
+
+    if np.ndim(value) != 0:
+        raise ValueError('{} must be a scalar, got shape {}'.format(
+            name_val, np.shape(value)))
+    if value != int(value):
+        raise ValueError('{} must be a whole number, got {}'.format(
+            name_val, value))
+    return int(value)
+
+
 class __ITU1853:
 
     """Tropospheric attenuation time series synthesis
@@ -536,9 +558,10 @@ def rain_attenuation_synthesis(lat, lon, f, el, hs, Ns, Ts=1, tau=45, n=None):
         estimate is obtained from the maps of topographic altitude
         given in Recommendation ITU-R P.1511.
     Ns : int
-        Number of samples
-    Ts : int
-        Time step between consecutive samples (seconds)
+        Number of samples. Must be a whole number
+    Ts : int or Quantity
+        Time step between consecutive samples (seconds). Must be a
+        whole number of samples
     tau : number, optional
         Polarization tilt angle relative to the horizontal (degrees)
         (tau = 45 deg for circular polarization). Default value is 45
@@ -563,7 +586,8 @@ def rain_attenuation_synthesis(lat, lon, f, el, hs, Ns, Ts=1, tau=45, n=None):
     f = prepare_quantity(f, u.GHz, "Frequency")
     el = prepare_quantity(el, u.deg, "Elevation angle")
     hs = prepare_quantity(hs, u.km, "Heigh above mean sea level of the earth station")
-    Ts = prepare_quantity(Ts, u.second, "Time step between samples")
+    Ns = _prepare_sample_count(Ns, "Number of samples")
+    Ts = _prepare_sample_count(Ts, "Time step between samples", u.second)
     val = __model.rain_attenuation_synthesis(
         lat, lon, f, el, hs, Ns, Ts=Ts, tau=tau, n=n
     )
@@ -579,11 +603,12 @@ def scintillation_attenuation_synthesis(Ns, f_c=0.1, Ts=1):
     Parameters
     ----------
     Ns : int
-        Number of samples
+        Number of samples. Must be a whole number
     f_c : float
         Cut-off frequency for the low pass filter
-    Ts : int
-        Time step between consecutive samples (seconds)
+    Ts : int or Quantity
+        Time step between consecutive samples (seconds). Must be a
+        whole number of samples
 
     Returns
     -------
@@ -598,6 +623,8 @@ def scintillation_attenuation_synthesis(Ns, f_c=0.1, Ts=1):
     """
     global __model  # noqa: F824
 
+    Ns = _prepare_sample_count(Ns, "Number of samples")
+    Ts = _prepare_sample_count(Ts, "Time step between samples", u.second)
     val = __model.scintillation_attenuation_synthesis(Ns, f_c, Ts)
     return val * u.dB
 
@@ -615,9 +642,10 @@ def integrated_water_vapour_synthesis(lat, lon, Ns, Ts=1, n=None):
     lon : number, sequence, or numpy.ndarray
         Longitudes of the receiver points
     Ns : int
-        Number of samples
-    Ts : int
-        Time step between consecutive samples (seconds)
+        Number of samples. Must be a whole number
+    Ts : int or Quantity
+        Time step between consecutive samples (seconds). Must be a
+        whole number of samples
     n : list, np.array, optional
         Additive White Gaussian Noise used as input for the
 
@@ -635,6 +663,8 @@ def integrated_water_vapour_synthesis(lat, lon, Ns, Ts=1, n=None):
     global __model  # noqa: F824
 
     lon = np.mod(lon, 360)
+    Ns = _prepare_sample_count(Ns, "Number of samples")
+    Ts = _prepare_sample_count(Ts, "Time step between samples", u.second)
     val = __model.integrated_water_vapour_synthesis(lat, lon, Ns, Ts, n)
     return val * u.kg / u.m**2
 
@@ -651,9 +681,10 @@ def cloud_liquid_water_synthesis(lat, lon, Ns, Ts=1, n=None):
     lon : number, sequence, or numpy.ndarray
         Longitudes of the receiver points
     Ns : int
-        Number of samples
-    Ts : int
-        Time step between consecutive samples (seconds)
+        Number of samples. Must be a whole number
+    Ts : int or Quantity
+        Time step between consecutive samples (seconds). Must be a
+        whole number of samples
     n : list, np.array, optional
         Additive White Gaussian Noise used as input for the
 
@@ -671,6 +702,8 @@ def cloud_liquid_water_synthesis(lat, lon, Ns, Ts=1, n=None):
     global __model  # noqa: F824
 
     lon = np.mod(lon, 360)
+    Ns = _prepare_sample_count(Ns, "Number of samples")
+    Ts = _prepare_sample_count(Ts, "Time step between samples", u.second)
     val = __model.cloud_liquid_water_synthesis(lat, lon, Ns, Ts, n)
     return val * u.mm
 
@@ -715,9 +748,10 @@ def total_attenuation_synthesis(
     D: number or Quantity
         Physical diameter of the earth-station antenna (m)
     Ns : int
-        Number of samples
-    Ts : int
-        Time step between consecutive samples (seconds)
+        Number of samples. Must be a whole number
+    Ts : int or Quantity
+        Time step between consecutive samples (seconds). Must be a
+        whole number of samples
     tau : number, optional
         Polarization tilt angle relative to the horizontal (degrees)
         (tau = 45 deg for circular polarization). Default value is 45
@@ -771,6 +805,8 @@ def total_attenuation_synthesis(
     H = prepare_quantity(H, u.percent, "Average surface relative humidity")
     P = prepare_quantity(P, u.hPa, "Average surface pressure")
     hL = prepare_quantity(hL, u.m, "Height of the turbulent layer")
+    Ns = _prepare_sample_count(Ns, "Number of samples")
+    Ts = _prepare_sample_count(Ts, "Time step between samples", u.second)
 
     val = __model.total_attenuation_synthesis(
         lat,

--- a/test/itur_test.py
+++ b/test/itur_test.py
@@ -36,7 +36,11 @@ def suite():
     suite.addTest(TestFunctionsRecommendation1510('test_1510'))
     suite.addTest(TestFunctionsRecommendation1511('test_1511'))
     suite.addTest(TestFunctionsRecommendation1623('test_1623'))
+    suite.addTest(TestFunctionsRecommendation1623(
+        'test_fade_depth_array_targets'))
     suite.addTest(TestFunctionsRecommendation1853('test_1853'))
+    suite.addTest(TestFunctionsRecommendation1853(
+        'test_sample_arguments_accept_quantities'))
 
     # Basic import module functionality
     suite.addTest(TestImportModules('test_import_itur'))
@@ -1036,6 +1040,60 @@ class TestFunctionsRecommendation1623(test.TestCase):
             self.test_all_functions_1623()
             self.assertEqual(models.itu1623.get_version(), version)
 
+    def test_fade_depth_array_targets(self):
+        # Regression test: `fade_depth` used to hand `fsolve` a scalar initial
+        # guess while the residual returned one value per element of
+        # `D_target`, so any non-scalar target raised `ValueError: The array
+        # returned by a function changed size between calls`. Each target pair
+        # is now solved independently.
+        # Attenuation CDF of the link under analysis, and the elevation and
+        # frequency it was measured at (same values as the `fade_depth`
+        # docstring example, whose expected answer is 21.6922280 dB)
+        PofA = np.array([50, 30, 20, 10, 5, 3, 2, 1, .5, .3, .2, .1, .05, .03,
+                         .02, .01, .005, .003, .002, .001])
+        A_arr = np.array([0.4, 0.6, 0.8, 1.8, 2.70, 3.5, 4.20, 5.7, 7.4, 9,
+                          10.60, 14, 18.3, 22.3, 25.8, 32.6, 40.1, 46.1, 50.8,
+                          58.8])
+        el = 38.5
+        f = 28
+
+        # The target the scalar reference answer corresponds to: 25 outage
+        # events per year, each lasting 60 s
+        N_ref, D_ref = 25, 60
+
+        for version in self.versions:
+            models.itu1623.change_version(version)
+
+            # Scalar targets keep returning a plain scalar
+            scalar = models.itu1623.fade_depth(
+                N_target=N_ref, D_target=D_ref,
+                A=A_arr, PofA=PofA, el=el, f=f)
+            self.assertEqual(np.ndim(scalar), 0)
+            self.assertAlmostEqual(scalar, 21.6922280, places=5)
+
+            # Arrays are solved element-wise; the entry matching the scalar
+            # target must reproduce the scalar answer exactly
+            by_duration = models.itu1623.fade_depth(
+                N_target=N_ref, D_target=np.array([30, D_ref, 120]),
+                A=A_arr, PofA=PofA, el=el, f=f)
+            self.assertEqual(by_duration.shape, (3,))
+            self.assertAlmostEqual(by_duration[1], scalar, places=10)
+
+            by_intensity = models.itu1623.fade_depth(
+                N_target=np.array([10, N_ref, 50]), D_target=D_ref,
+                A=A_arr, PofA=PofA, el=el, f=f)
+            self.assertEqual(by_intensity.shape, (3,))
+            self.assertAlmostEqual(by_intensity[1], scalar, places=10)
+
+            # Both targets broadcast against each other: a column of
+            # intensities against a row of durations gives a 2x2 grid
+            grid = models.itu1623.fade_depth(
+                N_target=np.array([[10], [N_ref]]),
+                D_target=np.array([30, D_ref]),
+                A=A_arr, PofA=PofA, el=el, f=f)
+            self.assertEqual(grid.shape, (2, 2))
+            self.assertAlmostEqual(grid[1, 1], scalar, places=10)
+
 
 class TestFunctionsRecommendation1853(test.TestCase):
 
@@ -1072,6 +1130,63 @@ class TestFunctionsRecommendation1853(test.TestCase):
             models.itu1853.change_version(version)
             self.test_all_functions_1853()
             self.assertEqual(models.itu1853.get_version(), version)
+
+    def test_sample_arguments_accept_quantities(self):
+        # Regression test: `Ns` and `Ts` are used as array sizes and slice
+        # steps, so they must reach numpy as integers. A float `Ts=1.0` -- and
+        # therefore also the documented `Ts=1 * u.s`, since a Quantity always
+        # stores its value as a float -- used to fail with `TypeError: slice
+        # indices must be integers` or `UnitConversionError`.
+        # Singapore: wet enough that 1000 samples are not all zeros, so the
+        # comparisons below are actually discriminating
+        lat = 1.4                   # latitude (deg)
+        lon = 103.8                 # longitude (deg)
+        f = 22 * itur.u.GHz         # frequency
+        el = 60                     # elevation angle (deg)
+        p = 1.0                     # exceedance probability (%)
+        D = 1 * itur.u.m            # antenna diameter
+        hs = 0 * itur.u.m           # height above mean sea level
+        Ns = 1000                   # number of samples
+
+        def synthesize(fname, Ns, Ts, **kwargs):
+            models.itu1853.set_seed(42)
+            val = getattr(models.itu1853, fname)(Ns=Ns, Ts=Ts, **kwargs)
+            return np.asarray(val.value, dtype=float)
+
+        # Each synthesis function, with the extra arguments it needs beyond
+        # `Ns` and `Ts`
+        cases = [
+            ('scintillation_attenuation_synthesis',
+             dict()),
+            ('rain_attenuation_synthesis',
+             dict(lat=lat, lon=lon, f=f, el=el, hs=hs)),
+            ('cloud_liquid_water_synthesis',
+             dict(lat=lat, lon=lon)),
+            ('integrated_water_vapour_synthesis',
+             dict(lat=lat, lon=lon)),
+            ('total_attenuation_synthesis',
+             dict(lat=lat, lon=lon, f=f, el=el, p=p, D=D)),
+        ]
+
+        models.itu1853.change_version(1)
+        for fname, kwargs in cases:
+            expected = synthesize(fname, Ns=Ns, Ts=1, **kwargs)
+            for Ts in (1.0, 1 * itur.u.s, np.int64(1)):
+                np.testing.assert_array_equal(
+                    synthesize(fname, Ns=Ns, Ts=Ts, **kwargs), expected,
+                    err_msg='%s disagrees for Ts=%r' % (fname, Ts))
+            # `Ns` gets the same treatment
+            np.testing.assert_array_equal(
+                synthesize(fname, Ns=float(Ns), Ts=1, **kwargs), expected,
+                err_msg='%s disagrees for a float Ns' % fname)
+
+        # A sampling interval that is not a whole number of samples is
+        # rejected up front rather than deep inside numpy
+        with self.assertRaises(ValueError):
+            models.itu1853.scintillation_attenuation_synthesis(Ns=Ns, Ts=1.5)
+        with self.assertRaises(ValueError):
+            models.itu1853.scintillation_attenuation_synthesis(
+                Ns=Ns, Ts=np.array([1, 2]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes the two issues turned up by the int/float audit on #112 and filed [in a comment there](https://github.com/inigodelportillo/ITU-Rpy/pull/112#issuecomment-5084429751). Independent of #112 — nothing here touches P.835.

## 1. `itu1623.fade_depth` could only be called with scalar targets

`_ITU1623_1_.fade_depth` hands `fsolve` a scalar initial guess, but the residual `delta_N_events` returned one value per element of `D_target`. Any non-scalar target therefore died inside scipy:

```python
itu1623.fade_depth(25, np.array([30, 60, 120]), A, PofA, el=38.5, f=28)
# ValueError: The array returned by a function changed size between calls
```

The `np.atleast_1d(D_target)` already in the function suggests arrays were meant to work.

**Fix.** `N_target` and `D_target` are broadcast against each other and each resulting pair is solved as its own root-finding problem. Scalar input still returns a plain scalar, so existing callers are untouched — the docstring example still yields `21.6922280` dB, and every element of an array run reproduces the corresponding scalar run to 10 decimal places.

```python
itu1623.fade_depth(N_target=25, D_target=np.array([30, 60, 120]),
                   A=A, PofA=PofA, el=38.5, f=28)
# array([24.70225606, 21.69222805, 18.28997423])
```

Docstring updated: the parameters were documented as scalar-only, and the return type is now scalar-or-array.

## 2. P.1853 synthesis functions rejected `Ts=1 * u.s`

`Ns` and `Ts` become array sizes and slice steps, so they have to reach numpy as integers. Only `rain_attenuation_synthesis` ran `Ts` through `prepare_quantity`, and that unwraps a Quantity to a **float**, not an int. So the library's own documented input convention was broken across the board:

| | `Ts=1` | `Ts=1.0` | `Ts=1 * u.s` |
|---|---|---|---|
| `rain_attenuation_synthesis` | ok | `TypeError` | `TypeError` |
| `scintillation_attenuation_synthesis` | ok | ok | `UnitConversionError` |
| `cloud_liquid_water_synthesis` | ok | `TypeError` | `UnitConversionError` |
| `integrated_water_vapour_synthesis` | ok | `TypeError` | `UnitConversionError` |
| `total_attenuation_synthesis` | ok | `TypeError` | `UnitConversionError` |

`TypeError: slice indices must be integers or None or have an __index__ method` — opaque, and a long way from the argument that caused it.

**Fix.** A shared `_prepare_sample_count` helper. All five wrappers now coerce both `Ns` and `Ts` through it, so `int`, integral `float`, `np.int64` and `Quantity` all give byte-identical results, and unit conversion works as expected (`Ts=1 * u.minute` == `Ts=60`). A non-integral or non-scalar value is rejected up front:

```
ValueError: Time step between samples must be a whole number, got 1.5
ValueError: Time step between samples must be a scalar, got shape (2,)
```

Verified on non-degenerate output — a 200 000-sample series at a wet site, where `Ts=2` genuinely differs from `Ts=1` — so the equality checks are discriminating rather than comparing all-zero arrays.

## Tests

Two regression tests, registered in `suite()`:

- `TestFunctionsRecommendation1623.test_fade_depth_array_targets` — scalar/array/broadcast shapes and cross-agreement, over both P.1623 versions.
- `TestFunctionsRecommendation1853.test_sample_arguments_accept_quantities` — all five synthesis functions across `int`/`float`/`Quantity`/`np.int64`, plus the two rejection cases.

Each fails on the parent commit with exactly the error quoted above.

Full suite: **162 tests, 0 failures**, 1 pre-existing error (`examples_test` fails to import — `ModuleNotFoundError: No module named 'matplotlib'`, also present on `master`).

One note for reviewers reproducing locally: running the suite regenerates `docs/validation/itur618_14.rst`, `itur676_13.rst` and `test_total_attenuation_table.html` as a side effect. Those regenerated files are deliberately **not** part of this branch. The 618-14 regeneration looks like a genuine content change (validation source moves from Rev 8.3.0 to rev 5.1 and gains a `rain_cross_polarization_discrimination` section), so the checked-in docs may be stale — worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
